### PR TITLE
Move SRMD Validator to SL5

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,19 @@
+name: Add new issue or pull request to sl5 project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/openMSL/projects/3
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
-    - uses: Persival-GmbH/spdx@master
+    - uses: enarx/spdx@master
       with:
         licenses: Apache-2.0 BSD-3-Clause BSD-2-Clause, MIT MPL-2.0

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -1,0 +1,17 @@
+name: SPDX License Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-spdx-headers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - uses: Persival-GmbH/spdx@master
+      with:
+        licenses: Apache-2.0 BSD-3-Clause BSD-2-Clause, MIT MPL-2.0


### PR DESCRIPTION
**Reference to a related issue in the repository**
https://github.com/openMSL/sl-1-5-sensor-model-testing/issues/36

**Add a description**
Move SRMD Validator into separate repo.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
